### PR TITLE
fix: Prevent request validation errors from appearing as a duplicate of internal validation errors in swagger docs.

### DIFF
--- a/src/fastapi_problem/handler.py
+++ b/src/fastapi_problem/handler.py
@@ -94,7 +94,7 @@ def customise_openapi(func: t.Callable[..., dict], *, generic_defaults: bool = T
                 "errors",
                 "status",
             ],
-            "title": "ValidationError",
+            "title": "RequestValidationError",
         }
         problem = {
             "properties": {

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -541,7 +541,7 @@ async def test_customise_openapi():
             "errors",
             "status",
         ],
-        "title": "ValidationError",
+        "title": "RequestValidationError",
     }
     assert "Problem" in res["components"]["schemas"]
     assert "ValidationError" in res["components"]["schemas"]
@@ -651,7 +651,7 @@ async def test_customise_openapi_generic_opt_out():
             "errors",
             "status",
         ],
-        "title": "ValidationError",
+        "title": "RequestValidationError",
     }
     assert "Problem" in res["components"]["schemas"]
     assert "ValidationError" in res["components"]["schemas"]


### PR DESCRIPTION
closes #33 