### PR TITLE
fix: Update content type to correctly match rfc9457 spec in swagger docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ source = ["src/fastapi_problem"]
 [tool.ruff]
 line-length = 120
 target-version = "py38"
+output-format = "concise"
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/src/fastapi_problem/handler.py
+++ b/src/fastapi_problem/handler.py
@@ -32,7 +32,7 @@ def _swagger_problem_response(description: str, title: str, status: str, type_: 
     return {
         "description": description,
         "content": {
-            "application/json": {
+            "application/problem+json": {
                 "schema": {
                     "$ref": "#/components/schemas/Problem",
                 },
@@ -144,6 +144,10 @@ def customise_openapi(func: t.Callable[..., dict], *, generic_defaults: bool = T
         if generic_defaults:
             for methods in res["paths"].values():
                 for details in methods.values():
+                    if "422" in details["responses"]:
+                        details["responses"]["422"]["content"]["application/problem+json"] = details["responses"][
+                            "422"
+                        ]["content"].pop("application/json")
                     details["responses"]["4XX"] = _swagger_problem_response(
                         description="Client Error",
                         title="User facing error message.",

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -449,7 +449,7 @@ def test_swagger_problem_response():
         status=400,
     ) == {
         "content": {
-            "application/json": {
+            "application/problem+json": {
                 "schema": {
                     "$ref": "#/components/schemas/Problem",
                 },
@@ -468,7 +468,7 @@ def test_swagger_problem_response():
 def test_generate_swagger_response_status_problem():
     assert handler.generate_swagger_response(error.BadRequestProblem) == {
         "content": {
-            "application/json": {
+            "application/problem+json": {
                 "schema": {
                     "$ref": "#/components/schemas/Problem",
                 },
@@ -487,7 +487,7 @@ def test_generate_swagger_response_status_problem():
 def test_generate_swagger_response_custom_problem():
     assert handler.generate_swagger_response(CustomUnhandledException) == {
         "content": {
-            "application/json": {
+            "application/problem+json": {
                 "schema": {
                     "$ref": "#/components/schemas/Problem",
                 },
@@ -560,7 +560,7 @@ async def test_customise_openapi():
         },
         "422": {
             "content": {
-                "application/json": {
+                "application/problem+json": {
                     "schema": {
                         "$ref": "#/components/schemas/HTTPValidationError",
                     },
@@ -570,7 +570,7 @@ async def test_customise_openapi():
         },
         "4XX": {
             "content": {
-                "application/json": {
+                "application/problem+json": {
                     "schema": {
                         "$ref": "#/components/schemas/Problem",
                     },
@@ -586,7 +586,7 @@ async def test_customise_openapi():
         },
         "5XX": {
             "content": {
-                "application/json": {
+                "application/problem+json": {
                     "schema": {
                         "$ref": "#/components/schemas/Problem",
                     },


### PR DESCRIPTION
closes #31 