### PR TITLE
feat: Add support for generating response examples for multiple exceptions under the same status code in swagger docs.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,7 +96,8 @@ add_exception_handler(
 
 To specify specific error responses per endpoint, when registering the route
 the swagger responses for each possible error can be generated using the
-`generate_swagger_response` helper method.
+`generate_swagger_response` helper method. Multiple exceptions can be provided
+if the route can return different errors of the same status code.
 
 ```
 from fastapi_problem.error import StatusProblem

--- a/examples/custom.py
+++ b/examples/custom.py
@@ -19,7 +19,7 @@ import logging
 
 import fastapi
 
-from fastapi_problem.handler import add_exception_handler, generate_swagger_response
+from fastapi_problem.handler import add_exception_handler
 from fastapi_problem.error import NotFoundProblem, ServerProblem, StatusProblem, UnprocessableProblem
 
 logging.getLogger("uvicorn.error").disabled = True
@@ -65,16 +65,7 @@ async def method_not_allowed() -> dict:
     return {}
 
 
-@app.get(
-    "/unexpected-error",
-    responses={
-        "404": generate_swagger_response(NotFoundProblem),
-        "409": generate_swagger_response(
-            ServerProblem,
-            CustomServer,
-        ),
-    },
-)
+@app.get("/unexpected-error")
 async def unexpected_error() -> dict:
     return {"value": 1 / 0}
 

--- a/examples/custom.py
+++ b/examples/custom.py
@@ -19,7 +19,7 @@ import logging
 
 import fastapi
 
-from fastapi_problem.handler import add_exception_handler
+from fastapi_problem.handler import add_exception_handler, generate_swagger_response
 from fastapi_problem.error import NotFoundProblem, ServerProblem, StatusProblem, UnprocessableProblem
 
 logging.getLogger("uvicorn.error").disabled = True
@@ -65,7 +65,16 @@ async def method_not_allowed() -> dict:
     return {}
 
 
-@app.get("/unexpected-error")
+@app.get(
+    "/unexpected-error",
+    responses={
+        "404": generate_swagger_response(NotFoundProblem),
+        "409": generate_swagger_response(
+            ServerProblem,
+            CustomServer,
+        ),
+    },
+)
 async def unexpected_error() -> dict:
     return {"value": 1 / 0}
 


### PR DESCRIPTION
closes #37 