### PR TITLE
feat: Add generate_swagger_response method to ExceptionHandler to support generating responses with documentation_uris.

### DIFF
--- a/docs/error.md
+++ b/docs/error.md
@@ -149,10 +149,10 @@ called with the type, title, status and any additional extras provided when the
 error is raised.
 
 ```python
-add_exception_handler(
-    app,
+eh = new_exception_handler(
     documentation_uri_template="https://link-to/my/errors/{type}",
 )
+add_exception_handler(app, eh)
 ```
 
 ```json
@@ -166,10 +166,10 @@ Where a full resolvable documentation uri does not exist, the rfc allows for a
 [tag uri](https://en.wikipedia.org/wiki/Tag_URI_scheme#Format).
 
 ```python
-add_exception_handler(
-    app,
-    documentation_uri_template="tag:my-domain.com,2024-01-01:{type}",
+eh = new_exception_handler(
+    documentation_uri_template="https://link-to/my/errors/{type}",
 )
+add_exception_handler(app, eh)
 ```
 
 ```json
@@ -188,11 +188,11 @@ in cases where the Problem doesn't explicitly define a `type_` attribute, the
 type will default to `about:blank`.
 
 ```python
-add_exception_handler(
-    app,
+eh = new_exception_handler(
     documentation_uri_template="https://link-to/my/errors/{type}",
     strict_rfc9457=True,
 )
+add_exception_handler(app, eh)
 ```
 
 ```json

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -24,7 +24,7 @@ A custom handler can then be defined in your application.
 import fastapi
 from rfc9457 import error_class_to_type
 from fastapi_problem.error import Problem
-from fastapi_problem.handler import ExceptionHandler, add_exception_handler
+from fastapi_problem.handler import ExceptionHandler, add_exception_handler, new_exception_handler
 from starlette.requests import Request
 
 from third_party.error import CustomBaseError
@@ -39,12 +39,12 @@ def my_custom_handler(eh: ExceptionHandler, request: Request, exc: CustomBaseErr
     )
 
 app = fastapi.FastAPI()
-add_exception_handler(
-    app,
+eh = new_exception_handler(
     handlers={
         CustomBaseError: my_custom_handler,
     },
 )
+add_exception_handler(app, eh)
 ```
 
 Any instance of CustomBaseError, or any subclasses, that reach the exception
@@ -63,7 +63,7 @@ previously defined, but rather than passing it to handlers, use the
 ```python
 import fastapi
 from fastapi_problem.error import Problem
-from fastapi_problem.handler import ExceptionHandler, add_exception_handler
+from fastapi_problem.handler import ExceptionHandler, add_exception_handler, new_exception_handler
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 
@@ -73,10 +73,10 @@ def my_custom_handler(eh: ExceptionHandler, request: Request, exc: HTTPException
 
 
 app = fastapi.FastAPI()
-add_exception_handler(
-    app,
+eh = new_excep, new_exception_handler(
     http_exception_handler=my_custom_handler,
 )
+add_exception_handler(app, eh)
 ```
 
 ### Optional handling
@@ -90,7 +90,7 @@ will be pass to the next defined handler.
 import fastapi
 from rfc9457 import error_class_to_type
 from fastapi_problem.error import Problem
-from fastapi_problem.handler import ExceptionHandler, add_exception_handler
+from fastapi_problem.handler import ExceptionHandler, add_exception_handler, new_exception_handler
 from starlette.requests import Request
 
 def no_response_handler(eh: ExceptionHandler, request: Request, exc: RuntimeError) -> Problem | None:
@@ -112,13 +112,13 @@ def base_handler(eh: ExceptionHandler, request: Request, exc: Exception) -> Prob
     )
 
 app = fastapi.FastAPI()
-add_exception_handler(
-    app,
+eh = new_exception_handler(
     handlers={
         RuntimeError: no_response_handler,
         Exception: base_handler,
     },
 )
+add_exception_handler(app, eh)
 ```
 
 At the time of writing there was (is?) a

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -12,7 +12,7 @@ for informational purposes such as logging or debugging.
 import logging
 
 import fastapi
-from fastapi_problem.handler import add_exception_handler
+from fastapi_problem.handler import add_exception_handler, new_exception_handler
 from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
@@ -24,10 +24,10 @@ def custom_hook(request: Request, exc: Exception) -> None:
 
 
 app = fastapi.FastAPI()
-add_exception_handler(
-    app,
+eh = new_exception_handler(
     pre_hooks=[custom_hook],
 )
+add_exception_handler(app, eh)
 ```
 
 ## Post Hooks
@@ -40,7 +40,7 @@ xml api etc, the raw content can be reprocessed.).
 
 ```python
 import fastapi
-from fastapi_problem.handler import add_exception_handler
+from fastapi_problem.handler import add_exception_handler, new_exception_handler
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -55,8 +55,8 @@ def custom_hook(content: dict, request: Request, response: Response) -> Response
 
 
 app = fastapi.FastAPI()
-add_exception_handler(
-    app,
+eh = new_exception_handler(
     post_hooks=[custom_hook],
 )
+add_exception_handler(app, eh)
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,7 +96,8 @@ add_exception_handler(
 
 To specify specific error responses per endpoint, when registering the route
 the swagger responses for each possible error can be generated using the
-`generate_swagger_response` helper method.
+`generate_swagger_response` helper method. Multiple exceptions can be provided
+if the route can return different errors of the same status code.
 
 ```
 from fastapi_problem.error import StatusProblem

--- a/examples/auth.py
+++ b/examples/auth.py
@@ -18,7 +18,7 @@ from fastapi_problem.error import (
     ForbiddenProblem,
     UnauthorisedProblem,
 )
-from fastapi_problem.handler import add_exception_handler
+from fastapi_problem.handler import add_exception_handler, new_exception_handler
 
 
 class AuthorizationRequiredError(UnauthorisedProblem):
@@ -46,9 +46,8 @@ async def check_auth(
 
 app = fastapi.FastAPI()
 
-add_exception_handler(
-    app,
-)
+eh = new_exception_handler()
+add_exception_handler(app, eh)
 
 
 @app.get("/authorized")

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -14,7 +14,7 @@ import logging
 import fastapi
 
 from fastapi_problem.error import BadRequestProblem, ServerProblem
-from fastapi_problem.handler import add_exception_handler
+from fastapi_problem.handler import add_exception_handler, new_exception_handler
 
 logging.getLogger("uvicorn.error").disabled = True
 
@@ -29,9 +29,8 @@ class KnownServerProblem(ServerProblem):
 
 app = fastapi.FastAPI()
 
-add_exception_handler(
-    app,
-)
+eh = new_exception_handler()
+add_exception_handler(app, eh)
 
 
 @app.get("/user-error")

--- a/examples/builtin.py
+++ b/examples/builtin.py
@@ -23,15 +23,14 @@ import logging
 import fastapi
 import pydantic
 
-from fastapi_problem.handler import add_exception_handler
+from fastapi_problem.handler import add_exception_handler, new_exception_handler
 
 logging.getLogger("uvicorn.error").disabled = True
 
 app = fastapi.FastAPI()
 
-add_exception_handler(
-    app,
-)
+eh = new_exception_handler()
+add_exception_handler(app, eh)
 
 
 @app.get("/validation-error")

--- a/examples/custom.py
+++ b/examples/custom.py
@@ -19,7 +19,7 @@ import logging
 
 import fastapi
 
-from fastapi_problem.handler import add_exception_handler, generate_swagger_response
+from fastapi_problem.handler import add_exception_handler
 from fastapi_problem.error import NotFoundProblem, ServerProblem, StatusProblem, UnprocessableProblem
 
 logging.getLogger("uvicorn.error").disabled = True
@@ -65,16 +65,7 @@ async def method_not_allowed() -> dict:
     return {}
 
 
-@app.get(
-    "/unexpected-error",
-    responses={
-        "404": generate_swagger_response(NotFoundProblem),
-        "409": generate_swagger_response(
-            ServerProblem,
-            CustomServer,
-        ),
-    },
-)
+@app.get("/unexpected-error")
 async def unexpected_error() -> dict:
     return {"value": 1 / 0}
 

--- a/examples/custom.py
+++ b/examples/custom.py
@@ -19,7 +19,7 @@ import logging
 
 import fastapi
 
-from fastapi_problem.handler import add_exception_handler
+from fastapi_problem.handler import add_exception_handler, new_exception_handler
 from fastapi_problem.error import NotFoundProblem, ServerProblem, StatusProblem, UnprocessableProblem
 
 logging.getLogger("uvicorn.error").disabled = True
@@ -44,8 +44,7 @@ class CustomServer(ServerProblem):
 
 app = fastapi.FastAPI()
 
-add_exception_handler(
-    app,
+eh = new_exception_handler(
     unhandled_wrappers={
         "404": CustomNotFound,
         "405": CustomNotAllowed,
@@ -53,6 +52,7 @@ add_exception_handler(
         "default": CustomServer,
     },
 )
+add_exception_handler(app, eh)
 
 
 @app.get("/validation-error")

--- a/examples/custom.py
+++ b/examples/custom.py
@@ -19,7 +19,7 @@ import logging
 
 import fastapi
 
-from fastapi_problem.handler import add_exception_handler
+from fastapi_problem.handler import add_exception_handler, generate_swagger_response
 from fastapi_problem.error import NotFoundProblem, ServerProblem, StatusProblem, UnprocessableProblem
 
 logging.getLogger("uvicorn.error").disabled = True
@@ -65,7 +65,16 @@ async def method_not_allowed() -> dict:
     return {}
 
 
-@app.get("/unexpected-error")
+@app.get(
+    "/unexpected-error",
+    responses={
+        "404": generate_swagger_response(NotFoundProblem),
+        "409": generate_swagger_response(
+            ServerProblem,
+            CustomServer,
+        ),
+    },
+)
 async def unexpected_error() -> dict:
     return {"value": 1 / 0}
 

--- a/examples/override.py
+++ b/examples/override.py
@@ -14,7 +14,7 @@ import logging
 import fastapi
 from starlette.exceptions import HTTPException
 
-from fastapi_problem.handler import ExceptionHandler, add_exception_handler
+from fastapi_problem.handler import ExceptionHandler, add_exception_handler, new_exception_handler
 from fastapi_problem.error import NotFoundProblem, Problem, ServerProblem, StatusProblem
 
 logging.getLogger("uvicorn.error").disabled = True
@@ -48,10 +48,10 @@ def http_exception_handler(
 
 app = fastapi.FastAPI()
 
-add_exception_handler(
-    app,
+eh = new_exception_handler(
     http_exception_handler=http_exception_handler,
 )
+add_exception_handler(app, eh)
 
 
 @app.post("/not-allowed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ select = ["ALL"]
 ignore = [
     "ANN002",  # ParamSpec not available in 3.9
     "ANN003",  # ParamSpec not available in 3.9
+    "E501",    # Handled by ruff format
     "FIX",  # allow TODO
     "D",
 ]

--- a/src/fastapi_problem/handler.py
+++ b/src/fastapi_problem/handler.py
@@ -65,7 +65,11 @@ def _swagger_problem_response(description: str, examples: list[Example]) -> dict
     return ret_val
 
 
-def generate_swagger_response(*exceptions: Problem, documentation_uri_template: str = "", strict: bool = False) -> dict:
+def _generate_swagger_response(
+    *exceptions: Problem,
+    documentation_uri_template: str = "",
+    strict: bool = False,
+) -> dict:
     examples = []
     for e in exceptions:
         exc = e("Additional error context.")
@@ -83,9 +87,22 @@ def generate_swagger_response(*exceptions: Problem, documentation_uri_template: 
     )
 
 
+def generate_swagger_response(*exceptions: Problem, documentation_uri_template: str = "", strict: bool = False) -> dict:
+    warn(
+        "Direct calls to generate_swagger_response are being deprecated, use `eh.generate_swagger_response(...)` instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    return _generate_swagger_response(
+        *exceptions,
+        documentation_uri_template=documentation_uri_template,
+        strict=strict,
+    )
+
+
 class ExceptionHandler(BaseExceptionHandler):
     def generate_swagger_response(self, *exceptions: Problem) -> dict:
-        return generate_swagger_response(
+        return _generate_swagger_response(
             *exceptions,
             documentation_uri_template=self.documentation_uri_template,
             strict=self.strict,

--- a/src/fastapi_problem/handler.py
+++ b/src/fastapi_problem/handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import typing as t
 from http.client import responses
+from warnings import warn
 
 import rfc9457
 from fastapi.exceptions import RequestValidationError
@@ -281,6 +282,12 @@ def add_exception_handler(  # noqa: PLR0913
     strict_rfc9457: bool = False,
 ) -> ExceptionHandler:
     if eh is None:
+        warn(
+            "Generating exception handler while adding is being deprecated, use `new_exception_handler(...)`..",
+            FutureWarning,
+            stacklevel=2,
+        )
+
         eh = new_exception_handler(
             logger=logger,
             cors=cors,

--- a/src/fastapi_problem/handler.py
+++ b/src/fastapi_problem/handler.py
@@ -9,13 +9,13 @@ from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException
 from starlette_problem.handler import (
     CorsPostHook,
-    ExceptionHandler,
     Handler,
     PostHook,
     PreHook,
     StripExtrasPostHook,
     http_exception_handler_,
 )
+from starlette_problem.handler import ExceptionHandler as BaseExceptionHandler
 
 from fastapi_problem.error import Problem, StatusProblem
 
@@ -39,7 +39,7 @@ def _swagger_problem_response(description: str, examples: list[Example]) -> dict
         ex.title: {
             "value": {
                 "title": ex.title,
-                "details": "Additional error context.",
+                "detail": "Additional error context.",
                 "type": ex.type_,
                 "status": ex.status,
             },
@@ -64,18 +64,31 @@ def _swagger_problem_response(description: str, examples: list[Example]) -> dict
     return ret_val
 
 
-def generate_swagger_response(*exceptions: Problem) -> dict:
-    return _swagger_problem_response(
-        responses[exceptions[0].status],
-        examples=[
+def generate_swagger_response(*exceptions: Problem, documentation_uri_template: str = "", strict: bool = False) -> dict:
+    examples = []
+    for e in exceptions:
+        exc = e("Additional error context.")
+        d = exc.marshal(uri=documentation_uri_template, strict=strict)
+        examples.append(
             Example(
-                title=exc.title,
-                type_=exc.type_ or rfc9457.error_class_to_type(exc("detail")),
-                status=exc.status,
-            )
-            for exc in exceptions
-        ],
+                title=d["title"],
+                type_=d["type"],
+                status=d["status"],
+            ),
+        )
+    return _swagger_problem_response(
+        responses[examples[0].status],
+        examples=examples,
     )
+
+
+class ExceptionHandler(BaseExceptionHandler):
+    def generate_swagger_response(self, *exceptions: Problem) -> dict:
+        return generate_swagger_response(
+            *exceptions,
+            documentation_uri_template=self.documentation_uri_template,
+            strict=self.strict,
+        )
 
 
 def customise_openapi(func: t.Callable[..., dict], *, generic_defaults: bool = True) -> t.Callable[..., dict]:
@@ -213,8 +226,7 @@ def request_validation_handler_(
     )
 
 
-def add_exception_handler(  # noqa: PLR0913
-    app: FastAPI,
+def new_exception_handler(  # noqa: PLR0913
     logger: logging.Logger | None = None,
     cors: CorsConfiguration | None = None,
     unhandled_wrappers: dict[str, type[StatusProblem]] | None = None,
@@ -225,7 +237,6 @@ def add_exception_handler(  # noqa: PLR0913
     http_exception_handler: Handler = http_exception_handler_,
     request_validation_handler: Handler = request_validation_handler_,
     *,
-    generic_swagger_defaults: bool = True,
     strict_rfc9457: bool = False,
 ) -> ExceptionHandler:
     handlers = handlers or {}
@@ -242,7 +253,7 @@ def add_exception_handler(  # noqa: PLR0913
         # Ensure it runs first before any custom modifications
         post_hooks.insert(0, CorsPostHook(cors))
 
-    eh = ExceptionHandler(
+    return ExceptionHandler(
         logger=logger,
         unhandled_wrappers=unhandled_wrappers,
         handlers=handlers,
@@ -251,6 +262,37 @@ def add_exception_handler(  # noqa: PLR0913
         documentation_uri_template=documentation_uri_template,
         strict_rfc9457=strict_rfc9457,
     )
+
+
+def add_exception_handler(  # noqa: PLR0913
+    app: FastAPI,
+    eh: ExceptionHandler or None = None,
+    *,
+    logger: logging.Logger | None = None,
+    cors: CorsConfiguration | None = None,
+    unhandled_wrappers: dict[str, type[StatusProblem]] | None = None,
+    handlers: dict[type[Exception], Handler] | None = None,
+    pre_hooks: list[PreHook] | None = None,
+    post_hooks: list[PostHook] | None = None,
+    documentation_uri_template: str = "",
+    http_exception_handler: Handler = http_exception_handler_,
+    request_validation_handler: Handler = request_validation_handler_,
+    generic_swagger_defaults: bool = True,
+    strict_rfc9457: bool = False,
+) -> ExceptionHandler:
+    if eh is None:
+        eh = new_exception_handler(
+            logger=logger,
+            cors=cors,
+            unhandled_wrappers=unhandled_wrappers,
+            handlers=handlers,
+            pre_hooks=pre_hooks,
+            post_hooks=post_hooks,
+            documentation_uri_template=documentation_uri_template,
+            http_exception_handler=http_exception_handler,
+            request_validation_handler=request_validation_handler,
+            strict_rfc9457=strict_rfc9457,
+        )
 
     app.add_exception_handler(Exception, eh)
     app.add_exception_handler(rfc9457.Problem, eh)
@@ -270,6 +312,7 @@ __all__ = [
     "PostHook",
     "PreHook",
     "StripExtrasPostHook",
+    "new_exception_handler",
     "add_exception_handler",
     "http_exception_handler_",
     "request_validation_handler_",


### PR DESCRIPTION
Rather than passing the same documentation_uri_template to all calls of generate_swagger_response, leverage the internal attributes of the ExceptionHandler.

closes #38 