### PR TITLE
fix(handler): fix an invalid type hint

### DIFF
--- a/src/fastapi_problem/handler.py
+++ b/src/fastapi_problem/handler.py
@@ -204,7 +204,7 @@ def new_exception_handler(  # noqa: PLR0913
 
 def add_exception_handler(  # noqa: PLR0913
     app: FastAPI,
-    eh: ExceptionHandler or None = None,
+    eh: ExceptionHandler | None = None,
     *,
     logger: logging.Logger | None = None,
     cors: CorsConfiguration | None = None,


### PR DESCRIPTION
Hi there, thanks for this library!

This fixes a small type annotation error in `handler.py` -- the annotation had `ExceptionHandler or None` instead of `ExceptionHandler | None`. This isn't detected by Python's own syntax checking because of deferred annotations, but Pyright flags it.

